### PR TITLE
fix: Overtime chart: x-axis should always start at 0 #33

### DIFF
--- a/tmv/test/test_overtime_visual.py
+++ b/tmv/test/test_overtime_visual.py
@@ -1,4 +1,6 @@
 import pytest
+import plotly.graph_objects as go
+
 from database import db
 from test.mock_objects import UserMock
 
@@ -11,25 +13,22 @@ from datetime import date, timedelta
 
 @pytest.mark.usefixtures("app")
 class TestOvertimeVisual:
-    @pytest.fixture(scope="function")
-    def ot_visual(self):
-        visual = OvertimeChartController()
-        return visual
-
-    def test_visual_initialized(self, ot_visual: OvertimeChartController):
-        assert ot_visual is not None
-
-    def test_earliest_and_latest_date(self, ot_visual, mocker):
-        # Create some OT measurements
+    @pytest.fixture(scope="module")
+    # Create some OT measurements
+    def dates(self):
         dates = (
             {date(2019, 3, 10), date(2019, 5, 5), date(2019, 5, 10)}
             | {date(2019, 8, day) for day in range(1, 32)}
             | {date(2019, 9, day) for day in range(1, 10)}
             | {date(2019, 10, 28)}
         )
+        return dates
 
+    def team(self):
         team = Team(parent_team=None, code="ABC", name="Team ABC")
+        return team
 
+    def set_db(self, dates, team):
         for measurement_date in dates:
             db.session.add(
                 OTMeasurement(
@@ -42,8 +41,49 @@ class TestOvertimeVisual:
             )
         db.session.commit()
 
-        mocker.patch("visuals.work_time.current_user", UserMock())
+    def mocker(self, mocker):
+        return mocker.patch("visuals.work_time.current_user", UserMock())
+
+    @pytest.fixture(scope="function")
+    def ot_visual(self):
+        visual = OvertimeChartController()
+        return visual
+
+    def test_visual_initialized(self, ot_visual: OvertimeChartController):
+        assert ot_visual is not None
+
+    def test_earliest_and_latest_date(self, ot_visual, mocker, dates, team):
+
+        self.set_db(dates, team)
+        self.mocker(mocker)
 
         # Check if dates in overtime chart match
         assert ot_visual.get_earliest_date() == min(dates)
         assert ot_visual.get_latest_date() == max(dates)
+
+    def test_added_traces_in_update(self, ot_visual, mocker, dates, team):
+
+        self.set_db(dates, team)
+        self.mocker(mocker)
+
+        data, layout = ot_visual.update(
+            ot_visual.get_latest_date(), ot_visual.get_latest_date()
+        )
+
+        first_trace = go.Box(
+            x=["2019-10-01 00:00:00"],
+            name="",
+            marker_color="rgba(0, 0, 0, 0)",
+            hoverinfo="none",
+        )
+
+        last_trace = go.Box(
+            x=["2019-10-01 00:00:00"],
+            name=" ",
+            marker_color="rgba(0, 0, 0, 0)",
+            hoverinfo="none",
+        )
+
+        assert layout is not None
+        assert first_trace in data
+        assert last_trace in data

--- a/tmv/test/test_shared.py
+++ b/tmv/test/test_shared.py
@@ -1,0 +1,28 @@
+import pytest  # pylint: disable=unused-import
+
+import pandas as pd
+from datetime import timedelta
+from visuals.shared import fix_timedelta_plot
+
+
+def test_fix_timedelta_plot():
+    timedelta_df0 = timedelta(0)
+    timedelta_df1 = pd.Timedelta("00:31:31")
+    active_date = "2020/1/1"
+    dflt_active_date = "1970/1/1"
+
+    # cases where both timedelta and active date are povided
+    assert fix_timedelta_plot(timedelta_df0, active_date) == (
+        timedelta_df0 + pd.to_datetime(active_date)
+    )
+    assert fix_timedelta_plot(timedelta_df1, active_date) == (
+        timedelta_df1 + pd.to_datetime(active_date)
+    )
+
+    # cases where timedelta is provided but active date is not
+    assert fix_timedelta_plot(timedelta_df0,) == (
+        timedelta_df0 + pd.to_datetime(dflt_active_date)
+    )
+    assert fix_timedelta_plot(timedelta_df1,) == (
+        timedelta_df1 + pd.to_datetime(dflt_active_date)
+    )

--- a/tmv/visuals/shared.py
+++ b/tmv/visuals/shared.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def fix_timedelta_plot(timedelta_df):
+def fix_timedelta_plot(timedelta_df, active_date="1970/1/1"):
     """
     Fix the display of timedelta-values in a plotly-plot.
 
@@ -13,4 +13,4 @@ def fix_timedelta_plot(timedelta_df):
     Ref.: https://community.plot.ly/t/timeseries-plot-with-timedelta-axis/23560
     and: https://github.com/plotly/plotly.py/issues/801#issuecomment-317174985
     """
-    return timedelta_df + pd.to_datetime("1970/1/1")
+    return timedelta_df + pd.to_datetime(active_date)

--- a/tmv/visuals/work_time.py
+++ b/tmv/visuals/work_time.py
@@ -125,7 +125,7 @@ class OvertimeChartController(VisualController):
             )
         )
 
-        result = pd.read_sql(
+        result = pd.read_sql_query(
             query.statement, db.session.bind, parse_dates=["measurement_date"],
         )
 
@@ -200,7 +200,8 @@ class OvertimeChartController(VisualController):
             go.Box(
                 x=[
                     fix_timedelta_plot(
-                        ot_per_day if ot_per_day > timedelta(0) else timedelta(0)
+                        ot_per_day if ot_per_day > timedelta(0) else timedelta(0),
+                        selected_start_period,
                     )
                     for ot_per_day in row["ot_per_day"]
                 ],
@@ -209,6 +210,24 @@ class OvertimeChartController(VisualController):
             )
             for _, row in data.iterrows()
         ]
+
+        # adding two extra points to traces to display the graph correctly
+        first_trace = go.Box(
+            x=[f"{selected_start_period} 00:00:00"],
+            name="",
+            marker_color="rgba(0, 0, 0, 0)",
+            hoverinfo="none",
+        )
+
+        last_trace = go.Box(
+            x=[f"{selected_start_period} 00:00:00"],
+            name=" ",
+            marker_color="rgba(0, 0, 0, 0)",
+            hoverinfo="none",
+        )
+
+        traces.insert(0, first_trace)
+        traces.append(last_trace)
 
         # Create readable title for the chart
         selected_start_period_readable = selected_start_period.strftime(
@@ -225,7 +244,7 @@ class OvertimeChartController(VisualController):
 
         layout = go.Layout(
             autosize=True,
-            margin=dict(t=70, l=30, r=30, b=30),
+            margin=dict(t=70, l=0, r=30, b=30),
             legend_orientation="h",
             font=dict(size=12),
             bargap=0.2,


### PR DESCRIPTION
**The changes below are related to issue  [#33](https://github.com/tri-ad/team-metrics-visualizer/issues/33)**
- changed shared.py to have the starting date to line up with the requested starting date
- modified worktime.py to have always an extra starting point at time "00:00"